### PR TITLE
Fix authentication check to await Supabase session

### DIFF
--- a/src/pages/login/index.jsx
+++ b/src/pages/login/index.jsx
@@ -25,10 +25,24 @@ const LoginPage = () => {
   };
 
   useEffect(() => {
-    // Check if user is already authenticated using auth utility
-    if (isAuthenticated()) {
-      navigate('/dashboard', { replace: true });
-    }
+    let isMounted = true;
+
+    const checkAuthentication = async () => {
+      try {
+        const authenticated = await isAuthenticated();
+        if (authenticated && isMounted) {
+          navigate('/dashboard', { replace: true });
+        }
+      } catch (error) {
+        console.error('Failed to verify authentication status:', error);
+      }
+    };
+
+    checkAuthentication();
+
+    return () => {
+      isMounted = false;
+    };
   }, [navigate]);
 
   return (

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -37,11 +37,18 @@ const MOCK_USERS = {
  * Check if user is currently authenticated
  * @returns {boolean} Authentication status
  */
-export const isAuthenticated = () => {
+export const isAuthenticated = async () => {
   try {
-    const session = supabase?.auth?.getSession()
-    return !!session?.data?.session?.user
-  } catch {
+    const { data, error } = await supabase?.auth?.getSession()
+
+    if (error) {
+      console.error('Error getting auth session:', error)
+      return false
+    }
+
+    return !!data?.session?.user
+  } catch (error) {
+    console.error('Error checking authentication status:', error)
     return false
   }
 };
@@ -153,9 +160,10 @@ export const performLogout = async (preservePreferences = false) => {
  * Update last activity timestamp
  * Used for session management and timeout detection
  */
-export const updateLastActivity = () => {
+export const updateLastActivity = async () => {
   try {
-    if (isAuthenticated()) {
+    const authenticated = await isAuthenticated()
+    if (authenticated) {
       localStorage.setItem(AUTH_KEYS?.LAST_ACTIVITY, new Date()?.toISOString());
     }
   } catch (error) {
@@ -168,13 +176,14 @@ export const updateLastActivity = () => {
  * @param {number} timeoutMinutes - Session timeout in minutes (default: 480 = 8 hours)
  * @returns {boolean} Whether session has expired
  */
-export const isSessionExpired = (timeoutMinutes = 480) => {
+export const isSessionExpired = async (timeoutMinutes = 480) => {
   try {
-    if (!isAuthenticated()) return true;
-    
+    const authenticated = await isAuthenticated()
+    if (!authenticated) return true;
+
     const lastActivity = localStorage.getItem(AUTH_KEYS?.LAST_ACTIVITY);
     if (!lastActivity) return true;
-    
+
     const lastActivityTime = new Date(lastActivity)?.getTime();
     const currentTime = new Date()?.getTime();
     const timeDifference = currentTime - lastActivityTime;


### PR DESCRIPTION
## Summary
- await the Supabase session request in the authentication helper and update dependent utilities
- handle the asynchronous authentication check when loading the login page to avoid false redirects

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de6fd8aee883298d96411622717a94